### PR TITLE
[#14] Response응답값 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ application-secret.yml
 
 ### VS Code ###
 .vscode/
+
+### DB ###
+/db
+
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  mysql:
+    image: mariadb:latest
+    container_name: mariadb
+    restart: always
+    ports:
+      - "13306:3306"
+    volumes:
+      - ./db/data:/var/lib/mysql:rw
+      - ./db/init:/docker-entrypoint-initdb.d:ro
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DOCKER_DB_PASSWORD}
+      MYSQL_DATABASE: ${DOCKER_DB_DATABASE}
+      TZ: ${DOCKER_TZ}

--- a/src/main/java/warriordiningback/api/user/dto/UserResponse.java
+++ b/src/main/java/warriordiningback/api/user/dto/UserResponse.java
@@ -14,6 +14,7 @@ import java.util.Set;
 public class UserResponse {
 
     private Long id;
+    private String name;
     private String email;
     private boolean isUsed;
     private Set<Role> roles;
@@ -24,14 +25,18 @@ public class UserResponse {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
 
+    private boolean status;
+
     public static UserResponse of(User user) {
         return UserResponse.builder()
                 .id(user.getId())
+                .name(user.getName())
                 .email(user.getEmail())
                 .isUsed(user.isUsed())
                 .roles(user.getRoles())
                 .createdAt(user.getCreatedAt())
                 .updatedAt(user.getUpdatedAt())
+                .status(true)
                 .build();
     }
 }

--- a/src/main/java/warriordiningback/token/TokenProvider.java
+++ b/src/main/java/warriordiningback/token/TokenProvider.java
@@ -68,6 +68,7 @@ public class TokenProvider {
                 .accessTokenExpireAt(accessTokenExpireAt)
                 .refreshToken(refreshToken)
                 .refreshTokenExpireAt(refreshTokenExpireAt)
+                .status(true)
                 .build();
     }
 

--- a/src/main/java/warriordiningback/token/response/TokenResponse.java
+++ b/src/main/java/warriordiningback/token/response/TokenResponse.java
@@ -12,7 +12,7 @@ public class TokenResponse {
     private String grantType;
 
     private String accessToken;
-    
+
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private Date accessTokenExpireAt;
 
@@ -20,4 +20,6 @@ public class TokenResponse {
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private Date refreshTokenExpireAt;
+
+    private boolean status;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,32 @@
 server:
   port: 8080
+
 spring:
   config:
-    import: application-secret.yml
+    import: optional:file:.env[.properties]
+
+  datasource:
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+logging:
+  level:
+    org:
+      hibernate:
+        sql: debug
+        type:
+          descriptor:
+            sql:
+              BasicBinder: trace
+
+jwt:
+  secret-key: ${SECRET_KEY}


### PR DESCRIPTION
Response 응답값 추가 및 수정하였습니다.
- 모든 Response응답
```json
{
   "status": true
}
```
status로 true값을 응답해주어 프론트에서 조건을 더욱 쉽게 걸 수 있도록 하였습니다.

- 회원가입 Response 응답
```json
{
   "name": "해당유저name"
}
```
name값을 응답해주어 회원가입 시 ~~~님 환영합니다 문구를 추가하였습니다.

- docker-compose.yml추가

프로젝트 내 터미널 혹은 터미널에서 프로젝트로 경로 변경 후
```java
docker-compose up -d
```
해당 명령어 사용하면 docker 컨테이너에 DB서버 생성되고 동일한 환경으로 로컬에서 개발진행하시면 됩니다.

- application.yml 시크릿 설정 env활용으로 변경

기존 application-secret.yml에서 env활용으로 변경하였습니다.
따로 공유해드린 env파일 프로젝트 최상단에 추가하여 추가적인 민감정보 생성 시 env파일에 `key=value`로 추가하고 해당 key 사용 시 ${key}로 추가하여 사용하시면 됩니다.

기본 민감정보 설정은 추가하였습니다!