### PR TITLE
[#51] 리프레쉬 토큰으로 액세스토큰 발급 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ application-secret.yml
 /db
 
 .env
+/src/main/resources/static/upload

--- a/src/main/java/warriordiningback/api/user/controller/UserController.java
+++ b/src/main/java/warriordiningback/api/user/controller/UserController.java
@@ -2,23 +2,26 @@ package warriordiningback.api.user.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
 import warriordiningback.api.user.dto.SignInRequest;
 import warriordiningback.api.user.dto.SignUpRequest;
 import warriordiningback.api.user.dto.UserResponse;
 import warriordiningback.api.user.service.UserService;
 import warriordiningback.domain.user.User;
+import warriordiningback.domain.user.UserRepository;
+import warriordiningback.exception.DiningApplicationException;
+import warriordiningback.exception.ErrorCode;
 import warriordiningback.token.response.TokenResponse;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/user")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
+    private final UserRepository userRepository;
 
     @PostMapping("/signin")
     public TokenResponse signIn(@RequestBody @Valid SignInRequest signInRequest) {
@@ -37,8 +40,13 @@ public class UserController {
         return UserResponse.of(user);
     }
 
-    @PostMapping("/test")
-    public String test() {
-        return "test 성공";
+
+    // 테스트용 메서드입니다.
+    @PostMapping("/test/{id}")
+    public UserResponse test(@PathVariable("id") Long id) {
+        User user = userRepository.findById(id).orElseThrow(
+                () -> new DiningApplicationException(ErrorCode.USER_NOT_FOUND)
+        );
+        return UserResponse.of(user);
     }
 }

--- a/src/main/java/warriordiningback/api/user/dto/UserResponse.java
+++ b/src/main/java/warriordiningback/api/user/dto/UserResponse.java
@@ -16,6 +16,7 @@ public class UserResponse {
     private Long id;
     private String name;
     private String email;
+    private String phone;
     private boolean isUsed;
     private Set<Role> roles;
 
@@ -32,6 +33,7 @@ public class UserResponse {
                 .id(user.getId())
                 .name(user.getName())
                 .email(user.getEmail())
+                .phone(user.getPhone())
                 .isUsed(user.isUsed())
                 .roles(user.getRoles())
                 .createdAt(user.getCreatedAt())

--- a/src/main/java/warriordiningback/api/user/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/warriordiningback/api/user/oauth/OAuthSuccessHandler.java
@@ -25,7 +25,12 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
                                         Authentication authentication) throws IOException {
         TokenResponse tokenResponse = tokenProvider.generateToken(authentication);
 
-        String redirectUrl = "http://localhost:3000/SignIn?accessToken=" + tokenResponse.getAccessToken();
+        String redirectUrl = "http://localhost:3000/SignIn?grantType="
+                + tokenResponse.getGrantType()
+                + "&accessToken="
+                + tokenResponse.getAccessToken()
+                + "&refreshToken="
+                + tokenResponse.getRefreshToken();
         response.sendRedirect(redirectUrl);
     }
 

--- a/src/main/java/warriordiningback/exception/ErrorCode.java
+++ b/src/main/java/warriordiningback/exception/ErrorCode.java
@@ -17,11 +17,11 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     INQUIRY_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 문의사항은 존재하지 않습니다."),
     CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 코드입니다."),
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 정보가 존재하지 않습니다. 다시 로그인해 주세요."),
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 음식점에 대한 정보가 존재하지 않습니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리뷰에 대한 정보가 존재하지 않습니다."),
 
-    
-    //403
+    //403,
     OWNER_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "해당 사용자에게 OWNER 권한이 없습니다.");
 
 

--- a/src/main/java/warriordiningback/token/JwtAuthenticationFilter.java
+++ b/src/main/java/warriordiningback/token/JwtAuthenticationFilter.java
@@ -1,46 +1,90 @@
 package warriordiningback.token;
 
+import com.google.gson.Gson;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.GenericFilterBean;
+import warriordiningback.exception.DiningApplicationException;
+import warriordiningback.exception.ErrorCode;
+import warriordiningback.exception.dto.DiningExceptionResponse;
+import warriordiningback.token.response.TokenResponse;
 
 import java.io.IOException;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends GenericFilterBean {
 
     private final TokenProvider tokenProvider;
+    private final String ACCESS = "Authorization1";
+    private final String REFRESH = "Authorization2";
 
     @Override
     public void doFilter(
             ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
             throws IOException, ServletException {
         // 1.Request Header에서 Jwt 토큰 추출
-        String token = resolveToken((HttpServletRequest) servletRequest);
+        String accessToken = resolveToken((HttpServletRequest) servletRequest, ACCESS);
+        String refreshToken = resolveToken((HttpServletRequest) servletRequest, REFRESH);
+        HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
 
-        // 2.validateToken으로 토큰 유효성 검사
-        if (token != null && tokenProvider.validateToken(token)) {
-            // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
-            Authentication authentication = tokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+        try {
+            // 2.validateToken으로 토큰 유효성 검사
+            if (accessToken != null) {
+                if (tokenProvider.validateToken(accessToken)) {
+                    // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
+                    Authentication authentication = tokenProvider.getAuthentication(accessToken);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    filterChain.doFilter(servletRequest, servletResponse);
+                } else if (tokenProvider.validateToken(refreshToken)) { // accessToken 만료 되었을 경우
+                    // 토큰 다시 생성
+                    TokenResponse tokenResponse = tokenProvider.refreshToken(refreshToken);
+                    httpResponse.getWriter().append(new Gson().toJson(tokenResponse));
+                } else {
+                    // 둘다 만료 처리
+                    DiningExceptionResponse errorResponse = new DiningExceptionResponse(
+                            ErrorCode.TOKEN_NOT_FOUND.getHttpStatus(), false, ErrorCode.TOKEN_NOT_FOUND.getMessage()
+                    );
+                    httpResponse.setContentType("application/json;charset=UTF-8");
+                    httpResponse.setStatus(HttpStatus.NOT_FOUND.value());
+                    httpResponse.getWriter().append(new Gson().toJson(errorResponse));
+                }
+            } else {
+                filterChain.doFilter(servletRequest, servletResponse);
+            }
+        } catch (DiningApplicationException exception) {
+            DiningExceptionResponse errorResponse = new DiningExceptionResponse(
+                    exception.getExceptionHttpStatus(), false, exception.getExceptionMessage()
+            );
+
+            httpResponse.setContentType("application/json;charset=UTF-8");
+            httpResponse.setStatus(exception.getExceptionHttpStatus().value());
+            httpResponse.getWriter().append(new Gson().toJson(errorResponse));
+
+        } catch (Exception e) {
+            DiningExceptionResponse errorResponse = new DiningExceptionResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR, false, "서버 오류가 발생했습니다." // 에러 메세지 어떻게 띄울지 상의해보기
+            );
+
+            httpResponse.setContentType("application/json;charset=UTF-8");
+            httpResponse.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+            httpResponse.getWriter().append(new Gson().toJson(errorResponse));
         }
-        filterChain.doFilter(servletRequest, servletResponse);
     }
-
+    
     // Request Header에서 토큰 정보 추출
-    private String resolveToken(HttpServletRequest httpServletRequest) {
-        String bearerToken = httpServletRequest.getHeader("Authorization");
+    private String resolveToken(HttpServletRequest httpServletRequest, String header) {
+        String bearerToken = httpServletRequest.getHeader(header);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }

--- a/src/main/java/warriordiningback/token/JwtAuthenticationFilter.java
+++ b/src/main/java/warriordiningback/token/JwtAuthenticationFilter.java
@@ -2,7 +2,6 @@ package warriordiningback.token;
 
 import com.google.gson.Gson;
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,7 +31,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     @Override
     public void doFilter(
             ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
-            throws IOException, ServletException {
+            throws IOException {
         // 1.Request Header에서 Jwt 토큰 추출
         String accessToken = resolveToken((HttpServletRequest) servletRequest, ACCESS);
         String refreshToken = resolveToken((HttpServletRequest) servletRequest, REFRESH);
@@ -81,7 +80,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             httpResponse.getWriter().append(new Gson().toJson(errorResponse));
         }
     }
-    
+
     // Request Header에서 토큰 정보 추출
     private String resolveToken(HttpServletRequest httpServletRequest, String header) {
         String bearerToken = httpServletRequest.getHeader(header);

--- a/src/main/java/warriordiningback/token/JwtAuthenticationFilter.java
+++ b/src/main/java/warriordiningback/token/JwtAuthenticationFilter.java
@@ -25,8 +25,8 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends GenericFilterBean {
 
     private final TokenProvider tokenProvider;
-    private final String ACCESS = "Authorization1";
-    private final String REFRESH = "Authorization2";
+    private final String ACCESS = "Authorization_Access";
+    private final String REFRESH = "Authorization_Refresh";
 
     @Override
     public void doFilter(

--- a/src/main/java/warriordiningback/token/TokenProvider.java
+++ b/src/main/java/warriordiningback/token/TokenProvider.java
@@ -42,7 +42,6 @@ public class TokenProvider {
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
 
-        long now = (new Date()).getTime();
         Map<String, String> header = new HashMap<>();
         header.put("alg", "H256");
         header.put("typ", "JWT");

--- a/src/main/java/warriordiningback/token/response/TokenResponse.java
+++ b/src/main/java/warriordiningback/token/response/TokenResponse.java
@@ -1,10 +1,7 @@
 package warriordiningback.token.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.Date;
 
 @Getter
 @Builder
@@ -13,13 +10,7 @@ public class TokenResponse {
 
     private String accessToken;
 
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private Date accessTokenExpireAt;
-
     private String refreshToken;
-
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private Date refreshTokenExpireAt;
 
     private boolean status;
 }

--- a/src/main/java/warriordiningback/token/service/CustomUserDetailsService.java
+++ b/src/main/java/warriordiningback/token/service/CustomUserDetailsService.java
@@ -1,7 +1,6 @@
 package warriordiningback.token.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -14,7 +13,6 @@ import warriordiningback.exception.ErrorCode;
 
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {


### PR DESCRIPTION
액세스토큰 만료시 리프레쉬 토큰을 이용하여 액세스토큰 재발급하는 로직 작성하였습니다.
전반적인 토큰발급로직 수정되었으며 불필요 응답값 제거하였습니다

- 로그인에 대한 response
```json
// as-is
{
    "grantType": "Bearer",
    "accessToken": "액세스 토큰 값",
    "accessTokenExpireAt": "2024-10-04 06:35:01",
    "refreshToken": "리프레쉬 토큰 값"
    "refreshTokenExpireAt": "2024-10-05 06:05:01"
}

// to-be
{
    "grantType": "Bearer",
    "accessToken": "액세스 토큰 값",
    "refreshToken": "리프레쉬 토큰 값",
    "status": true
}
```

토큰에 대한 유효성 검증 로직, 토큰 유효성에 대한 예외처리 `JwtAuthenticationFilter`에 코드 작성되어있습니다.
예외처리의 경우 Filter부분에서 ExceptionHandler가 캐치하지 못하여 직접적으로 값을 넣었습니다!
이 부분 확인하여 프론트 개발 시 에러 응답값이 어떻게 나가는지 확인해주시길 바랍니다
토큰 유효성에 대한 예외처리 메세지는 구분할 수 있게 입력해놓았으나 500 서버에러의 경우 메세지에 대해 한번 상의 후 설정하도록 하겠습니다.

추가적으로
첫번째 토큰 발급 시 재발급에 대한 테스트 할 수 있도록 일시적으로 1분으로 설정해 놓았습니다. 재발급 시 30분으로 발급됩니다!
userController의 test 메서드는 프론트 서버와 연동되어 있으며 테스트 용도 입니다. 프론트에서 재발급에 대한 테스트 시 실제 테스트가 이루어지도록 지우지않고 남겨놓았습니다.

필요하다고 생각되는부분에 주석달아 놓았는데
작성된 로직에 대하여 이해가 안되시는 분 있으면 따로 질문주시면 답변해드리겠습니다!!

close #51 