### PR TITLE
[사용자] 리뷰 슬라이드 수정

### DIFF
--- a/src/main/java/warriordiningback/api/restaurant/dto/ReviewData.java
+++ b/src/main/java/warriordiningback/api/restaurant/dto/ReviewData.java
@@ -10,5 +10,6 @@ public class ReviewData {
     private Long id;
     private String name;
     private String content;
+    private String placeName;
 
 }

--- a/src/main/java/warriordiningback/api/restaurant/service/PlaceReviewService.java
+++ b/src/main/java/warriordiningback/api/restaurant/service/PlaceReviewService.java
@@ -17,6 +17,6 @@ public class PlaceReviewService {
 
     public List<ReviewData> findByReview() {
         List<ReviewData> top10ReviewData = reviewRepository.findTop10ReviewData();
-        return top10ReviewData.stream().limit(10).toList();
+        return top10ReviewData.stream().limit(12).toList();
     }
 }

--- a/src/main/java/warriordiningback/domain/review/ReviewRepository.java
+++ b/src/main/java/warriordiningback/domain/review/ReviewRepository.java
@@ -14,8 +14,10 @@ import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    @Query("SELECT new warriordiningback.api.restaurant.dto.ReviewData(r.id, u.name, r.content) " +
-            "FROM Review r JOIN r.user u " +
+    @Query("SELECT new warriordiningback.api.restaurant.dto.ReviewData(r.id, u.name, r.content, p.name) " +
+            "FROM Review r " +
+            "JOIN r.user u " +
+            "JOIN r.place p " +
             "WHERE r.isDeleted = false " +
             "ORDER BY r.id DESC")
     List<ReviewData> findTop10ReviewData();


### PR DESCRIPTION
  -  [사용자] 리뷰 슬라이드 수정
     - 메인 리뷰 페이지 가게 이름 호출 추가
     - 리뷰 슬라이드 호출 리미트 변경
       - 4의 배수로 출력(프론트 화면 4개의 리뷰 표시)